### PR TITLE
Fixed bug with FQDNs in OWA Machine resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for OfficeOnlineServerDsc
 
+### Unreleased
+
+ * Fixed a bug that caused OfficeOnlineServerWebAppsMachine to fail a test when the machine to join 
+ was specified using a fully qualified domain name (FQDN)
+
 ### 0.1.0.0
 
  * First release of OfficeOnlineServerDsc

--- a/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerWebAppsMachine/MSFT_OfficeOnlineServerWebAppsMachine.psm1
+++ b/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerWebAppsMachine/MSFT_OfficeOnlineServerWebAppsMachine.psm1
@@ -185,7 +185,7 @@ function Test-TargetResource
     {
         return $false
     }
-} 
+}
 
 Export-ModuleMember -Function *-TargetResource
 

--- a/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerWebAppsMachine/MSFT_OfficeOnlineServerWebAppsMachine.psm1
+++ b/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerWebAppsMachine/MSFT_OfficeOnlineServerWebAppsMachine.psm1
@@ -156,9 +156,24 @@ function Test-TargetResource
         $roleCompare = Compare-Object -ReferenceObject $results.Roles -DifferenceObject $Roles
     }
     
+    if ($MachineToJoin.Contains(".") -eq $true)
+    {
+        $fqdn = $MachineToJoin
+        $computer = $MachineToJoin.Substring(0, $MachineToJoin.IndexOf("."))
+    }
+    else 
+    {
+        $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
+        $fqdn = "$MachineToJoin.$domain"
+        $computer = $MachineToJoin
+    }
+
+    $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
+    $fqdn = "$MachineToJoin.$domain"
+
     if (($results.Ensure -eq "Present") `
             -and ($Ensure -eq "Present") `
-            -and ($results.MachineToJoin -eq $MachineToJoin) `
+            -and (($results.MachineToJoin -eq $fqdn) -or ($results.MachineToJoin -eq $computer)) `
             -and ( $null -eq $roleCompare))
     {
         # If present and all value match return true

--- a/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerWebAppsMachine/MSFT_OfficeOnlineServerWebAppsMachine.psm1
+++ b/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerWebAppsMachine/MSFT_OfficeOnlineServerWebAppsMachine.psm1
@@ -185,7 +185,7 @@ function Test-TargetResource
     {
         return $false
     }
-}
+} 
 
 Export-ModuleMember -Function *-TargetResource
 

--- a/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerWebAppsMachine/MSFT_OfficeOnlineServerWebAppsMachine.psm1
+++ b/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerWebAppsMachine/MSFT_OfficeOnlineServerWebAppsMachine.psm1
@@ -168,9 +168,6 @@ function Test-TargetResource
         $computer = $MachineToJoin
     }
 
-    $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
-    $fqdn = "$MachineToJoin.$domain"
-
     if (($results.Ensure -eq "Present") `
             -and ($Ensure -eq "Present") `
             -and (($results.MachineToJoin -eq $fqdn) -or ($results.MachineToJoin -eq $computer)) `


### PR DESCRIPTION
Currently if a machine join is specified with a fully qualified name it will fail the test method. Added logic to account for FQDNs here to remove the incorrect false results.
- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/officeonlineserverdsc/4)

<!-- Reviewable:end -->
