### PR TITLE
Adding exit code 3010 to OOSInstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
     * Common Tests - Validate Script Files
     * Common Tests - Relative Path Length
     * Common Tests - Validate Markdown Links
+* OfficeOnlineServerInstall
+  * Updated error code checks to force reboot;
 
 ## 1.4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     * Common Tests - Validate Markdown Links
 * OfficeOnlineServerInstall
   * Updated error code checks to force reboot;
+  * Added check for CDROM to prevent issues with block file check;
 
 ## 1.4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * OfficeOnlineServerInstall
   * Updated resource to make sure the Windows Environment
     variables are loaded into the PowerShell session;
+  * Updated error code checks to force reboot;
 * OfficeOnlineServerMachine
   * Updated resource to make sure the Windows Environment
     variables are loaded into the PowerShell session;

--- a/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerInstall/MSFT_OfficeOnlineServerInstall.psm1
+++ b/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerInstall/MSFT_OfficeOnlineServerInstall.psm1
@@ -161,7 +161,7 @@ function Set-TargetResource
         }
         if ($null -ne $zone)
         {
-            throw ("PrerequisitesInstaller is blocked! Please use 'Unblock-File -Path " + `
+            throw ("Setup file is blocked! Please use 'Unblock-File -Path " + `
                     "$Path' to unblock the file before continuing.")
         }
         Write-Verbose -Message "File not blocked, continuing."

--- a/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerInstall/MSFT_OfficeOnlineServerInstall.psm1
+++ b/Modules/OfficeOnlineServerDsc/DSCResources/MSFT_OfficeOnlineServerInstall/MSFT_OfficeOnlineServerInstall.psm1
@@ -17,7 +17,7 @@ function Get-TargetResource
         $Path
     )
 
-    if ($Ensure -eq "Absent") 
+    if ($Ensure -eq "Absent")
     {
         throw "Uninstallation is not supported by OfficeOnlineServer Dsc"
     }
@@ -29,7 +29,7 @@ function Get-TargetResource
     {
         throw "Specified path cannot be found. {$Path}"
     }
-    
+
     Write-Verbose -Message "Checking file status of setup.exe"
     $zone = Get-Item $Path -Stream "Zone.Identifier" -EA SilentlyContinue
 
@@ -50,7 +50,7 @@ function Get-TargetResource
     {
         $localEnsure = "Present"
     }
-    
+
     return @{
         Ensure = $localEnsure
         Path = $Path
@@ -73,7 +73,7 @@ function Set-TargetResource
         $Path
     )
 
-    if ($Ensure -eq "Absent") 
+    if ($Ensure -eq "Absent")
     {
         throw "Uninstallation is not supported by OfficeOnlineServer Dsc"
     }
@@ -85,7 +85,7 @@ function Set-TargetResource
     {
         throw "Specified path cannot be found. {$Path}"
     }
-    
+
     Write-Verbose -Message "Checking file status of setup.exe"
     $zone = Get-Item $Path -Stream "Zone.Identifier" -EA SilentlyContinue
 
@@ -120,11 +120,19 @@ function Set-TargetResource
         Remove-OosDscZoneMap -ServerName $serverName
     }
 
+    # Exit codes: https://docs.microsoft.com/en-us/windows/desktop/msi/error-codes
     switch ($installer.ExitCode) {
-        0 { 
+        0
+        {
             Write-Verbose -Message "Installation of Office Online Server succeeded."
-         }
-        Default {
+        }
+        3010
+        {
+            Write-Verbose -Message "SharePoint binary installation complete, but reboot is required"
+            $global:DSCMachineStatus = 1
+        }
+        Default
+        {
             throw ("Office Online Server installation failed. Exit code " + `
                    "'$($installer.ExitCode)' was returned. Check " + `
                    "$($env:TEMP)\Wac Server Setup.log for further information")
@@ -149,11 +157,11 @@ function Test-TargetResource
         $Path
     )
 
-    if ($Ensure -eq "Absent") 
+    if ($Ensure -eq "Absent")
     {
         throw "Uninstallation is not supported by OfficeOnlineServer Dsc"
     }
-    
+
     Write-Verbose -Message "Testing for installation of Office Online Server"
     $result = Get-TargetResource @PSBoundParameters
 

--- a/Modules/OfficeOnlineServerDsc/Modules/OfficeOnlineServerDsc.Util/OfficeOnlineServerDsc.Util.psm1
+++ b/Modules/OfficeOnlineServerDsc/Modules/OfficeOnlineServerDsc.Util/OfficeOnlineServerDsc.Util.psm1
@@ -150,7 +150,7 @@ function Test-OosDscFarmOu
         [parameter(Mandatory = $true)]
         [string]
         $DesiredOU,
-        
+
         [parameter(Mandatory = $true)]
         [object]
         $ExistingOU
@@ -181,7 +181,7 @@ This method is used to compare current and desired values for any DSC resource
 
 This is hashtable of the current values that are applied to the resource
 
-.PARAMETER DesiredValues 
+.PARAMETER DesiredValues
 
 This is a PSBoundParametersDictionary of the desired values for the resource
 
@@ -196,15 +196,15 @@ function Test-OosDscParameterState() {
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true, Position=1)]  
+        [parameter(Mandatory = $true, Position=1)]
         [HashTable]
         $CurrentValues,
-        
-        [parameter(Mandatory = $true, Position=2)]  
+
+        [parameter(Mandatory = $true, Position=2)]
         [Object]
         $DesiredValues,
 
-        [parameter(Mandatory = $false, Position=3)] 
+        [parameter(Mandatory = $false, Position=3)]
         [Array]
         $ValuesToCheck
     )
@@ -213,52 +213,52 @@ function Test-OosDscParameterState() {
 
     if (($DesiredValues.GetType().Name -ne "HashTable") `
         -and ($DesiredValues.GetType().Name -ne "CimInstance") `
-        -and ($DesiredValues.GetType().Name -ne "PSBoundParametersDictionary")) 
+        -and ($DesiredValues.GetType().Name -ne "PSBoundParametersDictionary"))
     {
         throw ("Property 'DesiredValues' in Test-SPDscParameterState must be either a " + `
                "Hashtable or CimInstance. Type detected was $($DesiredValues.GetType().Name)")
     }
 
-    if (($DesiredValues.GetType().Name -eq "CimInstance") -and ($null -eq $ValuesToCheck)) 
+    if (($DesiredValues.GetType().Name -eq "CimInstance") -and ($null -eq $ValuesToCheck))
     {
         throw ("If 'DesiredValues' is a Hashtable then property 'ValuesToCheck' must contain " + `
                "a value")
     }
 
-    if (($null -eq $ValuesToCheck) -or ($ValuesToCheck.Count -lt 1)) 
+    if (($null -eq $ValuesToCheck) -or ($ValuesToCheck.Count -lt 1))
     {
         $KeyList = $DesiredValues.Keys
-    } 
-    else 
+    }
+    else
     {
         $KeyList = $ValuesToCheck
     }
 
     $KeyList | ForEach-Object -Process {
-        if ($_ -ne "Verbose") 
+        if ($_ -ne "Verbose")
         {
             if (($CurrentValues.ContainsKey($_) -eq $false) `
             -or ($CurrentValues.$_ -ne $DesiredValues.$_) `
-            -or (($DesiredValues.ContainsKey($_) -eq $true) -and ($DesiredValues.$_.GetType().IsArray))) 
+            -or (($DesiredValues.ContainsKey($_) -eq $true) -and ($DesiredValues.$_.GetType().IsArray)))
             {
                 if ($DesiredValues.GetType().Name -eq "HashTable" -or `
-                    $DesiredValues.GetType().Name -eq "PSBoundParametersDictionary") 
+                    $DesiredValues.GetType().Name -eq "PSBoundParametersDictionary")
                 {
                     $CheckDesiredValue = $DesiredValues.ContainsKey($_)
-                } 
-                else 
+                }
+                else
                 {
                     $CheckDesiredValue = Test-SPDSCObjectHasProperty $DesiredValues $_
                 }
 
-                if ($CheckDesiredValue) 
+                if ($CheckDesiredValue)
                 {
                     $desiredType = $DesiredValues.$_.GetType()
                     $fieldName = $_
-                    if ($desiredType.IsArray -eq $true) 
+                    if ($desiredType.IsArray -eq $true)
                     {
                         if (($CurrentValues.ContainsKey($fieldName) -eq $false) `
-                        -or ($null -eq $CurrentValues.$fieldName)) 
+                        -or ($null -eq $CurrentValues.$fieldName))
                         {
                             Write-Verbose -Message ("Expected to find an array value for " + `
                                                     "property $fieldName in the current " + `
@@ -266,12 +266,12 @@ function Test-OosDscParameterState() {
                                                     "was null. This has caused the test method " + `
                                                     "to return false.")
                             $returnValue = $false
-                        } 
-                        else 
+                        }
+                        else
                         {
                             $arrayCompare = Compare-Object -ReferenceObject $CurrentValues.$fieldName `
                                                            -DifferenceObject $DesiredValues.$fieldName
-                            if ($null -ne $arrayCompare) 
+                            if ($null -ne $arrayCompare)
                             {
                                 Write-Verbose -Message ("Found an array for property $fieldName " + `
                                                         "in the current values, but this array " + `
@@ -283,16 +283,16 @@ function Test-OosDscParameterState() {
                                 $returnValue = $false
                             }
                         }
-                    } 
-                    else 
+                    }
+                    else
                     {
-                        switch ($desiredType.Name) 
+                        switch ($desiredType.Name)
                         {
                             "String" {
                                 if ([string]::IsNullOrEmpty($CurrentValues.$fieldName) `
-                                -and [string]::IsNullOrEmpty($DesiredValues.$fieldName)) 
-                                {} 
-                                else 
+                                -and [string]::IsNullOrEmpty($DesiredValues.$fieldName))
+                                {}
+                                else
                                 {
                                     Write-Verbose -Message ("String value for property " + `
                                                             "$fieldName does not match. " + `
@@ -305,9 +305,9 @@ function Test-OosDscParameterState() {
                             }
                             "Int32" {
                                 if (($DesiredValues.$fieldName -eq 0) `
-                                -and ($null -eq $CurrentValues.$fieldName)) 
-                                {} 
-                                else 
+                                -and ($null -eq $CurrentValues.$fieldName))
+                                {}
+                                else
                                 {
                                     Write-Verbose -Message ("Int32 value for property " + `
                                                             "$fieldName does not match. " + `
@@ -320,9 +320,9 @@ function Test-OosDscParameterState() {
                             }
                             "Int16" {
                                 if (($DesiredValues.$fieldName -eq 0) `
-                                -and ($null -eq $CurrentValues.$fieldName)) 
-                                {} 
-                                else 
+                                -and ($null -eq $CurrentValues.$fieldName))
+                                {}
+                                else
                                 {
                                     Write-Verbose -Message ("Int16 value for property " + `
                                                             "$fieldName does not match. " + `
@@ -342,9 +342,9 @@ function Test-OosDscParameterState() {
                             }
                         }
                     }
-                }            
+                }
             }
-        } 
+        }
     }
     return $returnValue
 }

--- a/Tests/Unit/OfficeOnlineserverDSC/MSFT_OfficeOnlineServerInstallLanguagePack.tests.ps1
+++ b/Tests/Unit/OfficeOnlineserverDSC/MSFT_OfficeOnlineServerInstallLanguagePack.tests.ps1
@@ -17,7 +17,7 @@ Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHel
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Script:DSCModuleName `
     -DSCResourceName $Script:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 
 try
 {
@@ -26,7 +26,7 @@ try
 
             Import-Module (Join-Path $PSScriptRoot "..\..\..\Modules\OfficeOnlineServerDsc" -Resolve)
             Remove-Module -Name "OfficeWebApps" -Force -ErrorAction SilentlyContinue
-            Import-Module $Global:CurrentWACCmdletModule -WarningAction SilentlyContinue 
+            Import-Module $Global:CurrentWACCmdletModule -WarningAction SilentlyContinue
 
             Context "Office Online Server 2016 is not installed but should be" {
                 $testParams = @{


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds exit code 3010 to OOSInstall, which indicates that install was successful, but a reboot is required.

#### This Pull Request (PR) fixes the following issues
- Fixes #46 

#### Task list
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/officeonlineserverdsc/47)
<!-- Reviewable:end -->
